### PR TITLE
Separate app logic from core or external/vendor logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ It has:
 
 see [Docs](https://github.com/mindaugasbarysas/bashwithnails/blob/master/docs/man.md) or clone and run for more information.
 
-
 ## How to run
 
 `./app.sh`

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -106,7 +106,7 @@ function bootstrap_module_from_namespace()
     local MDIR
     for MDIR in $LOCAL_MODULE_DIR $MODULE_DIR
     do
-        grep -Re "#NAMESPACE=${1}$" $SCRIPT_DIR/$MDIR/* | cut -d: -f 1 | sed -e "s/\(.*\)$MDIR\///g"
+        grep -Re "#NAMESPACE=${1}$" $SCRIPT_DIR/$MDIR/ | cut -d: -f 1 | sed -e "s/\(.*\)$MDIR\///g" 2>&1
     done
 }
 
@@ -115,7 +115,7 @@ function bootstrap_load_namespace()
     local MDIR
     for MDIR in $LOCAL_MODULE_DIR $MODULE_DIR
     do
-        for module in `grep -Re "NAMESPACE=${1}$" $SCRIPT_DIR/$MDIR/* | cut -d: -f 1 | sed -e "s/$SCRIPT_DIR\/$MDIR\//g"`
+        for module in `grep -Re "NAMESPACE=${1}$" $SCRIPT_DIR/$MDIR/ | cut -d: -f 1 | sed -e "s/$SCRIPT_DIR\/$MDIR\//g"`
         do
             MDIR=`echo $MDIR | rev`
             bootstrap_load_module $module

--- a/modules/core/oop
+++ b/modules/core/oop
@@ -14,7 +14,7 @@ function new(namespace constructor_args object_name) {
     this::increase_num
     local MOD=`bootstrap_module_from_namespace $namespace`
     local TEMPFILE=`mktemp /tmp/sh-oop-${ID}.XXXXXXXXXX`
-    bootstrap_prepare_module $ID $MOD > $TEMPFILE
+    bootstrap_prepare_module $ID $MOD $MODULE_DIR > $TEMPFILE
     . $TEMPFILE
     rm $TEMPFILE
     namespaced IDLIST+=($ID)

--- a/modules/core/packager
+++ b/modules/core/packager
@@ -3,9 +3,14 @@
 
 dependencies::register_module "core/packager"
 
-namespaced REPO_ADDRESS=$GLOBAL_REPOSITORY_ADDRESS;
+namespaced REPO_ADDRESS="$GLOBAL_REPOSITORY_ADDRESS";
 namespaced CACHE_DIR=$GLOBAL_CACHE_DIR;
 namespaced GETTER_FUNC=this::wget_getter
+
+if [[ ! -d ${namespaced CACHE_DIR} ]]
+then
+    mkdir -p ${namespaced CACHE_DIR}
+fi
 
 function set_repository(repository_address) {
     namespaced REPO_ADDRESS=$repository_address;
@@ -34,7 +39,7 @@ function wget_getter(url destination) {
 
 function get_module(module_name) {
     module_name=${module_name//./}
-    for repo in ${namespaced REPO_ADDRESS}
+    for repo in ${namespaced REPO_ADDRESS[@]}
     do
         if [[ -f ${repo} ]]
         then
@@ -43,11 +48,11 @@ function get_module(module_name) {
             local filename=${namespaced CACHE_DIR}/`echo "${repo}" | $MD5 | cut -d\  -f1`
             if [[ ! -f $filename ]]
             then
-                    ${namespaced GETTER_FUNC} ${namespaced REPO_ADDRESS} $filename
+                    ${namespaced GETTER_FUNC} ${repo} $filename
                     if [[ $? -ne 0 ]]
                     then
                         rm $filename
-                        echo "repository not found at ${namespaced REPO_ADDRESS}"
+                        echo "repository not found at ${repo}"
                         bootstrap_trace
                         return $ERROR_NOT_FOUND
                     fi

--- a/vars/environment.sh
+++ b/vars/environment.sh
@@ -5,6 +5,7 @@ SCRIPT_DIR=$DIR
 GLOBAL_REPOSITORY_ADDRESS="https://raw.githubusercontent.com/mindaugasbarysas/bashwithnails/master/sample_repo/repofile"
 GLOBAL_CACHE_DIR="$DIR/cache"
 MODULE_DIR="modules"
+LOCAL_MODULE_DIR="app"
 if [[ -f /sbin/md5 ]]
 then
     MD5='/sbin/md5'


### PR DESCRIPTION
* separate external libraries/modules from application modules

* in case of missing env variables, load sane defaults